### PR TITLE
Feature/same domain option

### DIFF
--- a/crau/cli.py
+++ b/crau/cli.py
@@ -67,7 +67,7 @@ def extract_uri(warc_filename, uri, output):
 @click.option("--input-encoding", default="utf-8")
 @click.option("--cache", is_flag=True)
 @click.option("--max-depth", default=1)
-@click.option("--same-domain", is_flag=True, default=False)
+@click.option("--match-domains", multiple=True, default=[])
 @click.option("--log-level", required=False)
 @click.option("--user-agent", required=False)
 @click.option("--settings", "-s", multiple=True, default=[], callback=load_settings)
@@ -112,7 +112,7 @@ def archive(
         warc_filename=warc_filename,
         urls=urls,
         max_depth=max_depth,
-        same_domain=same_domain,
+        match_domains=match_domains,
     )
     process.start()
     # TODO: if there's an error, print it

--- a/crau/cli.py
+++ b/crau/cli.py
@@ -67,6 +67,7 @@ def extract_uri(warc_filename, uri, output):
 @click.option("--input-encoding", default="utf-8")
 @click.option("--cache", is_flag=True)
 @click.option("--max-depth", default=1)
+@click.option("--same-domain", is_flag=True, default=False)
 @click.option("--log-level", required=False)
 @click.option("--user-agent", required=False)
 @click.option("--settings", "-s", multiple=True, default=[], callback=load_settings)
@@ -107,7 +108,11 @@ def archive(
 
     process = CrawlerProcess(settings=settings)
     process.crawl(
-        CrauSpider, warc_filename=warc_filename, urls=urls, max_depth=max_depth
+        CrauSpider,
+        warc_filename=warc_filename,
+        urls=urls,
+        max_depth=max_depth,
+        same_domain=same_domain,
     )
     process.start()
     # TODO: if there's an error, print it

--- a/crau/cli.py
+++ b/crau/cli.py
@@ -67,7 +67,7 @@ def extract_uri(warc_filename, uri, output):
 @click.option("--input-encoding", default="utf-8")
 @click.option("--cache", is_flag=True)
 @click.option("--max-depth", default=1)
-@click.option("--match-domains", multiple=True, default=[])
+@click.option("--allowed", multiple=True, default=[])
 @click.option("--log-level", required=False)
 @click.option("--user-agent", required=False)
 @click.option("--settings", "-s", multiple=True, default=[], callback=load_settings)
@@ -112,7 +112,7 @@ def archive(
         warc_filename=warc_filename,
         urls=urls,
         max_depth=max_depth,
-        match_domains=match_domains,
+        allowed=allowed,
     )
     process.start()
     # TODO: if there's an error, print it

--- a/crau/utils.py
+++ b/crau/utils.py
@@ -183,3 +183,18 @@ def write_warc_request_response(writer, response):
             http_headers=http_headers,
         )
     )
+
+
+def resource_matches_base_url(absolute_url, allowed):
+    clean_allowed = []
+    for allow in allowed:
+        if not allow.startswith("http"):
+            allow = f"http://{allow}"
+
+        clean_allowed.append(urlparse(allow.replace("www.", "")))
+
+    parsed_url = urlparse(absolute_url.replace("www.", ""))
+    return (
+        any(a.netloc == parsed_url.netloc and parsed_url.path.startswith(a.path) for a in clean_allowed)
+        or not allowed
+    )

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -3,6 +3,7 @@
 autoflake
 black
 ipython
+pytest==7.1.1
 isort
 twine
 wheel

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,74 @@
+from crau.utils import resource_matches_base_url
+
+
+def test_resource_matches_base_url_empty_allowed_list():
+    urls = [
+        "https://url.com",
+        "https://example.com",
+        "https://net.br/path",
+    ]
+    allowed = []
+    for url in urls:
+        assert resource_matches_base_url(url, allowed) is True
+
+
+def test_resource_matches_base_url_allowed_is_domain():
+    urls = [
+        ("https://url.com", False),
+        ("https://example.com", True),
+        ("https://example.com/anything", True),
+        ("https://facebook.com/example.com", False),
+        ("https://net.br/path", False),
+    ]
+    allowed = ["example.com"]
+    for url, match_ in urls:
+        assert resource_matches_base_url(url, allowed) is match_, url
+
+
+def test_resource_matches_base_url_allowed_is_domain_with_scheme():
+    urls = [
+        ("https://url.com", False),
+        ("https://example.com", True),
+        ("http://example.com/anything", True),
+        ("https://facebook.com/example.com", False),
+        ("https://net.br/path", False),
+    ]
+    allowed = ["http://example.com"]
+    for url, match_ in urls:
+        assert resource_matches_base_url(url, allowed) is match_, url
+
+    allowed = ["https://example.com"]
+    for url, match_ in urls:
+        assert resource_matches_base_url(url, allowed) is match_, url
+
+
+def test_resource_matches_base_url_allowed_domain_with_path():
+    urls = [
+        ("https://url.com", False),
+        ("https://example.com", False),
+        ("https://example.com/path", True),
+        ("https://example.com/path/root", True),
+        ("https://example.com/anything", False),
+        ("https://facebook.com/example.com", False),
+        ("https://net.br/path", False),
+    ]
+    allowed = ["example.com/path"]
+    for url, match_ in urls:
+        assert resource_matches_base_url(url, allowed) is match_, url
+
+
+def test_resource_matches_base_url_miscelaneous_allowed():
+    urls = [
+        ("https://url.com", False),
+        ("https://example.com", False),
+        ("https://example.com/path", True),
+        ("https://example.com/path/root", True),
+        ("https://example.com/anything", False),
+        ("https://facebook.com/example.com", False),
+        ("https://www.twitter.com/profile/username", True),
+        ("https://www.twitter.com/example.com", False),
+        ("https://net.br/path", False),
+    ]
+    allowed = ["example.com/path", "twitter.com/profile"]
+    for url, match_ in urls:
+        assert resource_matches_base_url(url, allowed) is match_, url


### PR DESCRIPTION
Adicionei dois commits. Um deles adiciona um argumento que é booleano e ira checar se um recurso contém a URL base ou inicial. 

Já no outro commit estendi este argumento e o transformei numa lista de domínios. Para um recurso (que não seja media, css etc) ser arquivado ele deve dar `match` em um desses domínios.

Precisei criar um método auxiliar `is_href`, pois percebi que alguns assets estavam vindo com `resource.name` igual a `other`. Por exemplo, alguns arquivos .png vem com `resource.name` igual a `other`.

### Alguns resultados 

#### Código para teste

```python
from scrapy.crawler import CrawlerProcess

from crau.spider import CrauSpider


if __name__ == "__main__":
    warc_filename = "output/aosfatos_apagar.warc.gz"
    max_depth = 2
    urls = ["https://www.aosfatos.org"]
    settings = {"LOG_LEVEL": "INFO"}

    process = CrawlerProcess(settings=settings)
    process.crawl(
        CrauSpider,
        warc_filename=warc_filename,
        urls=urls,
        max_depth=max_depth,
        match_domains=["www.aosfatos.org", "bbc.com"]
    )
    process.start()

```

#### Warc full

```
ls -lh collections/aosfatos_full/archive/aosfatos_full.warc.gz
169M

crau list collections/aosfatos_full/archive/aosfatos_full.warc.gz | wc -l
5117

crau list collections/aosfatos_full/archive/aosfatos_full.warc.gz | grep "facebook.com" | wc -l
 206
```

#### Warc slim

```
ls -lh collections/aosfatos_slim/archive/aosfatos_slim.warc.gz
160M

crau list collections/aosfatos_slim/archive/aosfatos_slim.warc.gz | wc -l
2183

crau list collections/aosfatos_slim/archive/aosfatos_slim.warc.gz | grep "facebook.com" | wc -l
1

# https://www.aosfatos.org/noticias/bolsonaristas-acumulam-12-milhao-de-interacoes-no-facebook-com-desinformacao-sobre-a-cpi-da-covid-19/
```